### PR TITLE
Implement docker environment configuration.

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,7 @@ LABEL version="1.0" maintainer="Unknownue <unknownue@outlook.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ADD mirror-ubuntu1604.txt /etc/apt/sources.list
+# ADD mirror-ubuntu1604.txt /etc/apt/sources.list
 
 RUN apt update && \
     apt install -y software-properties-common && \
@@ -22,8 +22,8 @@ RUN apt update && \
     ln -sf /usr/bin/python3.6 /usr/bin/python3 && \
     ln -sf /usr/bin/pip3 /usr/bin/pip
 
-RUN pip install pqi && \
-    pqi use aliyun
+# RUN pip install pqi && \
+#     pqi use aliyun
 
 # Install tensorflow
 RUN pip install --no-cache-dir tensorflow-gpu==1.11.0

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,7 @@ LABEL version="1.0" maintainer="Unknownue <unknownue@outlook.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# COPY mirror-ubuntu1604.txt /etc/apt/sources.list
+ADD mirror-ubuntu1604.txt /etc/apt/sources.list
 
 RUN apt update && \
     apt install -y software-properties-common && \
@@ -22,8 +22,8 @@ RUN apt update && \
     ln -sf /usr/bin/python3.6 /usr/bin/python3 && \
     ln -sf /usr/bin/pip3 /usr/bin/pip
 
-# RUN pip install pqi && \
-#     pqi use aliyun
+RUN pip install pqi && \
+    pqi use aliyun
 
 # Install tensorflow
 RUN pip install --no-cache-dir tensorflow-gpu==1.11.0

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,41 @@
+
+From nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+
+LABEL version="1.0" maintainer="Unknownue <unknownue@outlook.com>"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# COPY mirror-ubuntu1604.txt /etc/apt/sources.list
+
+RUN apt update && \
+    apt install -y software-properties-common && \
+    apt install -y wget git && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test
+
+# Install python and pip
+RUN apt update && \
+    apt install -y python3.6 python3.6-tk && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python3.6 get-pip.py && rm get-pip.py && \
+    ln -sf /usr/bin/python3.6 /usr/bin/python && \
+    ln -sf /usr/bin/python3.6 /usr/bin/python3 && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip
+
+# RUN pip install pqi && \
+#     pqi use aliyun
+
+# Install tensorflow
+RUN pip install --no-cache-dir tensorflow-gpu==1.11.0
+RUN pip install --no-cache-dir numpy==1.15.4 matplotlib==2.2.0 scikit-learn==0.20.0 && \
+    pip install --no-cache-dir plyfile Pillow tqdm
+
+RUN pip install --no-cache-dir open3d==0.9.0 && \
+    apt install -y libgl1-mesa-glx python-apt && \
+    cp /usr/lib/python3/dist-packages/apt_pkg.cpython-35m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so && \
+    apt update && \
+    apt upgrade -y libstdc++6 && \
+    rm /usr/bin/python && \
+    ln -sf /usr/bin/python3.6 /usr/bin/python
+
+CMD ["bash"]

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,38 @@
+
+## Step to Training
+
+```bash
+git clone https://github.com/liruihui/PU-GAN.git
+cd PU-GAN/Docker
+docker build -t tensorflow/pu-gan -f Dockerflie .
+```
+
+### Replace shell scripts under this directory to original ones
+```bash
+cp tf_approxmatch_compile.sh ../tf_ops/approxmatch/tf_approxmatch_compile.sh
+cp tf_grouping_compile.sh ../tf_ops/grouping/tf_grouping_compile.sh
+cp tf_interpolate_compile.sh ../tf_ops/interpolation/tf_interpolate_compile.sh
+cp tf_nndistance_compile.sh ../tf_ops/nn_distance/tf_nndistance_compile.sh
+cp tf_sampling_compile.sh ../tf_ops/sampling/tf_sampling_compile.sh
+
+cp compile.sh ../tf_ops/compile.sh
+```
+
+### Start training
+```bash
+cd ../
+docker run -it --rm \
+    -e DISPLAY=unix$DISPLAY \
+    -v $(pwd):/workspace/ \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -w /workspace \
+    --name pu-gan-runtime \
+    --gpus all \
+    --shm-size 8G \
+    tensorflow/pu-gan
+
+cd tf_ops
+bash compile.sh
+cd ../
+python pu_gan.py --phase train
+```

--- a/Docker/compile.sh
+++ b/Docker/compile.sh
@@ -1,0 +1,16 @@
+
+cd approxmatch
+echo 'approxmatch...'
+bash tf_approxmatch_compile.sh
+cd ../grouping
+echo 'grouping...'
+bash tf_grouping_compile.sh
+cd ../interpolation
+echo 'interpolation...'
+bash tf_interpolate_compile.sh
+cd ../nn_distance
+echo 'nn_distance...'
+bash tf_nndistance_compile.sh
+cd ../sampling
+echo 'sampling...'
+bash tf_sampling_compile.sh

--- a/Docker/tf_approxmatch_compile.sh
+++ b/Docker/tf_approxmatch_compile.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#/bin/bash
+
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+
+# TF1.4
+# /usr/local/cuda-10.1/bin/nvcc tf_approxmatch_g.cu -o tf_approxmatch_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+nvcc tf_approxmatch_g.cu -o tf_approxmatch_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+#g++ -std=c++11 tf_approxmatch.cpp tf_approxmatch_g.cu.o -o tf_approxmatch_so.so -shared -fPIC -I /usr/local/lib/python2.7/dist-packages/tensorflow/include -I /usr/local/cuda-8.0/include -I /usr/local/lib/python2.7/dist-packages/tensorflow/include/external/nsync/public -lcudart -L /usr/local/cuda-8.0/lib64/ -L/usr/local/lib/python2.7/dist-packages/tensorflow -ltensorflow_framework -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+g++ -std=c++11 tf_approxmatch.cpp tf_approxmatch_g.cu.o -o tf_approxmatch_so.so -shared -fPIC -O2 -I /usr/local/cuda-9.0/include -L/usr/local/cuda-9.0/lib64 ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -lcudart -I$TF_INC/external/nsync/public -L$TF_LIB -ltensorflow_framework -D_GLIBCXX_USE_CXX11_ABI=0

--- a/Docker/tf_grouping_compile.sh
+++ b/Docker/tf_grouping_compile.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#/bin/bash
+
+
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+
+
+nvcc tf_grouping_g.cu -o tf_grouping_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+g++ -std=c++11 tf_grouping.cpp tf_grouping_g.cu.o -o tf_grouping_so.so -shared -fPIC -O2 -I /usr/local/cuda-9.0/include -L/usr/local/cuda-9.0/lib64 ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -lcudart -I$TF_INC/external/nsync/public -L$TF_LIB -ltensorflow_framework -D_GLIBCXX_USE_CXX11_ABI=0
+#g++ -std=c++11 tf_grouping.cpp tf_grouping_g.cu.o -o tf_grouping_so.so -shared -fPIC -I /usr/local/lib/python2.7/dist-packages/tensorflow/include -I /usr/local/cuda-8.0/include -I /usr/local/lib/python2.7/dist-packages/tensorflow/include/external/nsync/public -lcudart -L /usr/local/cuda-8.0/lib64/ -L/usr/local/lib/python2.7/dist-packages/tensorflow -ltensorflow_framework -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+

--- a/Docker/tf_interpolate_compile.sh
+++ b/Docker/tf_interpolate_compile.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+
+#g++ -std=c++11 tf_interpolate.cpp -o tf_interpolate_so.so -shared -fPIC -I /home/lirh/anaconda3/envs/tensorflow3/lib/python3.6/site-packages/tensorflow/include  -I /usr/local/cuda-8.0/include -lcudart -L /usr/local/cuda-8.0/lib64/ -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+#g++ -std=c++11 tf_interpolate.cpp -o tf_interpolate_so.so -shared -fPIC -I /home/lirh/anaconda3/envs/tensorflow3/lib/python2.7/site-packages/tensorflow/include  -I /usr/local/cuda-8.0/include -lcudart -L /usr/local/cuda-8.0/lib64/ -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+
+g++ -std=c++11 tf_interpolate.cpp -o tf_interpolate_so.so -shared -fPIC -O2 -I /usr/local/cuda-9.0/include -L/usr/local/cuda-9.0/lib64 ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -lcudart -I$TF_INC/external/nsync/public -L$TF_LIB -ltensorflow_framework -D_GLIBCXX_USE_CXX11_ABI=0
+

--- a/Docker/tf_nndistance_compile.sh
+++ b/Docker/tf_nndistance_compile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+
+nvcc tf_nndistance_g.cu -o tf_nndistance_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+#g++ -std=c++11 tf_nndistance.cpp tf_nndistance_g.cu.o -o tf_nndistance_so.so -shared -fPIC -I /usr/local/lib/python2.7/dist-packages/tensorflow/include -I /usr/local/cuda-8.0/include -I /usr/local/lib/python2.7/dist-packages/tensorflow/include/external/nsync/public -lcudart -L /usr/local/cuda-8.0/lib64/ -L/usr/local/lib/python2.7/dist-packages/tensorflow -ltensorflow_framework -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+g++ -std=c++11 tf_nndistance.cpp tf_nndistance_g.cu.o -o tf_nndistance_so.so -shared -O2 -fPIC -I /usr/local/cuda-9.0/include -L/usr/local/cuda-9.0/lib64 ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -lcudart -I$TF_INC/external/nsync/public -L$TF_LIB -ltensorflow_framework -D_GLIBCXX_USE_CXX11_ABI=0
+

--- a/Docker/tf_sampling_compile.sh
+++ b/Docker/tf_sampling_compile.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#/bin/bash
+
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+
+
+nvcc tf_sampling_g.cu -o tf_sampling_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+#g++ -std=c++11 tf_sampling.cpp tf_sampling_g.cu.o -o tf_sampling_so.so -shared -fPIC -I /data/lirh/anaconda3/envs/tensorflow3/lib/python3.6/site-packages/tensorflow/include  -I /usr/local/cuda-8.0/include -lcudart -L /usr/local/cuda-8.0/lib64/ -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+g++ -std=c++11 tf_sampling.cpp tf_sampling_g.cu.o -o tf_sampling_so.so -shared -fPIC -O2 -I /usr/local/cuda-9.0/include -L/usr/local/cuda-9.0/lib64 ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -lcudart -I$TF_INC/external/nsync/public -L$TF_LIB -ltensorflow_framework -D_GLIBCXX_USE_CXX11_ABI=0

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ by [Ruihui Li](https://liruihui.github.io/), [Xianzhi Li](https://nini-lxz.githu
 
 This repository is for our ICCV 2019 paper '[PU-GAN: a Point Cloud Upsampling Adversarial Network](https://liruihui.github.io/publication/PU-GAN/)'. The code is modified from [3PU](https://github.com/yifita/3PU) and [PU-Net](https://github.com/yulequan/PU-Net). 
 
+### Docker
+A Dockerfile is provided to help you relief the pain of configurate training environment. 
+
+See the instructions in [here](./Docker).
+
 ### Installation
 This repository is based on Tensorflow and the TF operators from PointNet++. Therefore, you need to install tensorflow and compile the TF operators. 
 

--- a/tf_ops/approxmatch/tf_approxmatch_compile copy.sh
+++ b/tf_ops/approxmatch/tf_approxmatch_compile copy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#/bin/bash
+
+TF_INC=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_include())')
+TF_LIB=$(python -c 'import tensorflow as tf; print(tf.sysconfig.get_lib())')
+TF_CFLAGS=( $(python3 -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
+TF_LFLAGS=( $(python3 -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+
+# TF1.4
+# /usr/local/cuda-10.1/bin/nvcc tf_approxmatch_g.cu -o tf_approxmatch_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+nvcc tf_approxmatch_g.cu -o tf_approxmatch_g.cu.o -c -O2 -DGOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+#g++ -std=c++11 tf_approxmatch.cpp tf_approxmatch_g.cu.o -o tf_approxmatch_so.so -shared -fPIC -I /usr/local/lib/python2.7/dist-packages/tensorflow/include -I /usr/local/cuda-8.0/include -I /usr/local/lib/python2.7/dist-packages/tensorflow/include/external/nsync/public -lcudart -L /usr/local/cuda-8.0/lib64/ -L/usr/local/lib/python2.7/dist-packages/tensorflow -ltensorflow_framework -O2 -D_GLIBCXX_USE_CXX11_ABI=0
+g++ -std=c++11 tf_approxmatch.cpp tf_approxmatch_g.cu.o -o tf_approxmatch_so.so -shared -fPIC -O2 -I /usr/local/cuda-9.0/include -L/usr/local/cuda-9.0/lib64 ${TF_CFLAGS[@]} ${TF_LFLAGS[@]} -lcudart -I$TF_INC/external/nsync/public -L$TF_LIB -ltensorflow_framework -D_GLIBCXX_USE_CXX11_ABI=0


### PR DESCRIPTION
It's hard to config the training environment for this repo, since you have no idea which package is not compatible.
This PR implement training environment configuration in docker. By running the code in provided docker container, the user only need to know the basic usage of docker to start. No need to set up virtualenv or conda. No need to dual with cuda version incompatibility.

One of the key point in this configuration is that the code must be running under **ubuntu16.04**(i.e. the base docker image must be ubuntu16.04). Using ubuntu18.04 or upper version will result in `Segmentation fault (core dumped)` in `sess.run()` without telling you which line of code trigger the error. You almost have **no way** to debug the code in `sess.run()`. And people generally would not switch their OS just to make the code run.

I'm sure the docker configuration does help next coming people saving their time to make the code does run.
I think providing a docker configuration for their own ML repo is the responsibility for the paper author. It not only explains all the steps to reproduction, but also eliminate questions about environment set up. 